### PR TITLE
Feature image markdown

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -58,8 +58,14 @@ browser.action.onClicked.addListener(async (tab) => {
 
 browser.contextMenus.create({
     id: 'copy-markdown-link',
-    title: 'Copy markdown link to here',
+    title: 'Create markdown of selected text',
     contexts: ['all'],
+});
+
+browser.contextMenus.create({
+    id: 'copy-image-link',
+    title: 'Create markdown of image',
+    contexts: ['image']
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -107,6 +107,11 @@ async function handleDoubleClick() {
     }
 }
 
+function getImage(url) {
+    console.log('url of image:', url);
+    // pass this to content.js to build the markdown syntax
+}
+
 /**
  * sendCopyMessage sends a message to the content script to get the ID of the
  * right-clicked HTML element and then writes a markdown link to the clipboard.

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -73,8 +73,8 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
         case 'copy-markdown-link':
             sendCopyMessage(info, tab);
             break;
-        case 'copy-image-link':
-            getImage(info.srcUrl);
+        case 'image':
+            buildImageMarkdown(info, tab);
             break;
         default:
             console.log('Unknown menu item');
@@ -107,10 +107,21 @@ async function handleDoubleClick() {
     }
 }
 
-function getImage(url) {
-    console.log('url of image:', url);
-    // pass this to content.js to build the markdown syntax
+function buildImageMarkdown(info, tab) {
+    console.log('info: ', info);
+    console.log('tab: ', tab);
+    const url = info.srcUrl;
+    const { filename, filetype } = url => {
+        const endingPath = url.split('/').pop(); // converts string into a list object & removes the last element
+        const lastDot = endingPath.lastIndexOf('.');
+        if(lastDot > 0) {
+            const filename = endingPath.substring(0, lastDot); // substring of all characters before the '.'
+            const extension = endingPath.substring(lastDot); // substring of all characters after the '.'
+            return { filename, extension };
+        } else { return { filename: endingPath, extension: '' } } // cases where the image extension
+    } 
 }
+
 
 /**
  * sendCopyMessage sends a message to the content script to get the ID of the

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -69,8 +69,15 @@ browser.contextMenus.create({
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
-    if (info.menuItemId === 'copy-markdown-link') {
-        sendCopyMessage(info, tab);
+    switch (info.menuItemId) {
+        case 'copy-markdown-link':
+            sendCopyMessage(info, tab);
+            break;
+        case 'copy-image-link':
+            getImage(info.srcUrl);
+            break;
+        default:
+            console.log('Unknown menu item');
     }
 });
 

--- a/chromium/content.js
+++ b/chromium/content.js
@@ -27,8 +27,8 @@ window.onload = function () {
         true,
     );
 
-    browser.runtime.onMessage.addListener(function (category, sender, sendResponse) {
-        if (category === 'all') {
+    browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+        if (message.category === 'all') {
             // if clickedElement doesn't have an id, look at its parent
             while (clickedElement && !clickedElement.id) {
                 clickedElement = clickedElement.parentElement;
@@ -39,6 +39,12 @@ window.onload = function () {
                 console.log('No HTML element with an ID was found in the clicked path');
                 sendResponse('');
             }
+        } else if (message.category === 'image') {
+            navigator.clipboard.writeText(message.markdown).then(() => {
+                sendResponse(`${message.category}:${message.filename}`);
+            }).catch((error) => {
+                console.error("Failed to copy text to clipboard:", error);
+            });
         }
         return true;
     });

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -8,6 +8,7 @@
         "activeTab",
         "clipboardWrite",
         "contextMenus",
+        "notifications",
         "scripting",
         "storage"
     ],


### PR DESCRIPTION
When the mouse is hovering over an image, the Stardown menu will add an additional option to create markdown syntax of the image using the source url from the page. 

I've added an additional feature of having Stardown create a notification that the markdown was successfully created. Where in the case of the image, it provides the name of the image which is extrapolated from its filename.

Changes to `content.js` was necessary on the selection side to address the message object I was sending vs the string literal being used by selection, so the type that the `onMessage` method was receiving was a consistent data type.

This PR will close issue#13