### PR TITLE
Deduplicate

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+import { getSetting } from "./common";
+
 if (typeof browser === 'undefined') {
     var browser = chrome;
 }
@@ -556,23 +558,4 @@ async function brieflyShowX() {
 
 async function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * getSetting gets a setting from the browser's sync storage.
- * @param {string} name - the name of the setting.
- * @param {any} default_ - the default value of the setting.
- * @returns {any}
- */
-async function getSetting(name, default_) {
-    try {
-        const v = (await browser.storage.sync.get(name))[name];
-        if (v === undefined) {
-            return default_;
-        }
-        return v;
-    } catch (err) {
-        console.error(err);
-        return default_;
-    }
 }

--- a/chromium/common.js
+++ b/chromium/common.js
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 Chris Wheeler
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+if (typeof browser === 'undefined') {
+    var browser = chrome;
+}
+
+/**
+ * getSetting gets a setting from the browser's sync storage.
+ * @param {string} name - the name of the setting.
+ * @param {any} default_ - the default value of the setting.
+ * @returns {Promise<any>}
+ */
+export async function getSetting(name, default_) {
+    try {
+        const v = (await browser.storage.sync.get(name))[name];
+        if (v === undefined) {
+            return default_;
+        }
+        return v;
+    } catch (err) {
+        console.error(err);
+        return default_;
+    }
+}

--- a/chromium/content.js
+++ b/chromium/content.js
@@ -103,25 +103,6 @@ window.onload = function () {
 }
 
 /**
- * getSetting gets a setting from the browser's sync storage.
- * @param {string} name - the name of the setting.
- * @param {any} default_ - the default value of the setting.
- * @returns {any}
- */
-async function getSetting(name, default_) {
-    try {
-        const v = (await browser.storage.sync.get(name))[name];
-        if (v === undefined) {
-            return default_;
-        }
-        return v;
-    } catch (err) {
-        console.error(err);
-        return default_;
-    }
-}
-
-/**
  * replaceBrackets replaces square brackets in a link title with the character or escape
  * sequence chosen in settings.
  * @param {string} title - the raw link title.

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -28,6 +28,7 @@
             ],
             "js": [
                 "content.js",
+                "common.js",
                 "fragment-generation-utils.js",
                 "text-fragment-utils.js"
             ]

--- a/chromium/options.html
+++ b/chromium/options.html
@@ -100,6 +100,7 @@ as the options page. -->
       <input id="reset" type="reset" />
     </form>
 
+    <script src="common.js" type="module"></script>
     <script src="options.js"></script>
   </body>
 

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+import { getSetting } from "./common";
+
 if (typeof browser === 'undefined') {
     var browser = chrome;
 }
@@ -76,25 +78,6 @@ async function resetOptions() {
         button.value = 'Reset';
         button.style.backgroundColor = '';
     }, 750);
-}
-
-/**
- * getSetting gets a setting from the browser's sync storage.
- * @param {string} name - the name of the setting.
- * @param {any} default_ - the default value of the setting.
- * @returns {any}
- */
-async function getSetting(name, default_) {
-    try {
-        const v = (await browser.storage.sync.get(name))[name];
-        if (v === undefined) {
-            return default_;
-        }
-        return v;
-    } catch (err) {
-        console.error(err);
-        return default_;
-    }
 }
 
 document.addEventListener("DOMContentLoaded", loadOptions);

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+import { getSetting } from "./common";
+
 if (typeof browser === 'undefined') {
     var browser = chrome;
 }
@@ -474,23 +476,4 @@ async function brieflyShowX() {
 
 async function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * getSetting gets a setting from the browser's sync storage.
- * @param {string} name - the name of the setting.
- * @param {any} default_ - the default value of the setting.
- * @returns {any}
- */
-async function getSetting(name, default_) {
-    try {
-        const v = (await browser.storage.sync.get(name))[name];
-        if (v === undefined) {
-            return default_;
-        }
-        return v;
-    } catch (err) {
-        console.error(err);
-        return default_;
-    }
 }

--- a/firefox/common.js
+++ b/firefox/common.js
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 Chris Wheeler
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+if (typeof browser === 'undefined') {
+    var browser = chrome;
+}
+
+/**
+ * getSetting gets a setting from the browser's sync storage.
+ * @param {string} name - the name of the setting.
+ * @param {any} default_ - the default value of the setting.
+ * @returns {Promise<any>}
+ */
+export async function getSetting(name, default_) {
+    try {
+        const v = (await browser.storage.sync.get(name))[name];
+        if (v === undefined) {
+            return default_;
+        }
+        return v;
+    } catch (err) {
+        console.error(err);
+        return default_;
+    }
+}

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -34,6 +34,7 @@
             ],
             "js": [
                 "content.js",
+                "common.js",
                 "create-text-fragment-arg.js",
                 "fragment-generation-utils.js",
                 "text-fragment-utils.js"

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -95,6 +95,7 @@
       <input id="reset" type="reset" />
     </form>
 
+    <script src="common.js" type="module"></script>
     <script src="options.js"></script>
   </body>
 

--- a/firefox/options.js
+++ b/firefox/options.js
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+import { getSetting } from "./common";
+
 if (typeof browser === 'undefined') {
     var browser = chrome;
 }
@@ -76,25 +78,6 @@ async function resetOptions() {
         button.value = 'Reset';
         button.style.backgroundColor = '';
     }, 750);
-}
-
-/**
- * getSetting gets a setting from the browser's sync storage.
- * @param {string} name - the name of the setting.
- * @param {any} default_ - the default value of the setting.
- * @returns {any}
- */
-async function getSetting(name, default_) {
-    try {
-        const v = (await browser.storage.sync.get(name))[name];
-        if (v === undefined) {
-            return default_;
-        }
-        return v;
-    } catch (err) {
-        console.error(err);
-        return default_;
-    }
 }
 
 document.addEventListener("DOMContentLoaded", loadOptions);


### PR DESCRIPTION
Some functions including the `getSetting` function are defined multiple times. For example, `getSetting` in the Chromium version of Stardown is defined in each of background.js, content.js, and options.js. It would be nice if there's a way to define `getSetting` only in one separate file, `common.js`, and import it into the other files. I'm not sure how to do that yet though. The current changes in this PR don't work yet; they give this error:

![Screenshot 2024-05-25 150122](https://github.com/wheelercj/Stardown/assets/39012918/d6e40452-1e1e-47d1-abba-51ba3814e404)

Removing the import statement gives this error:

![Screenshot 2024-05-25 150922](https://github.com/wheelercj/Stardown/assets/39012918/304c0fac-8186-42b8-af14-c9f9ed225055)

Maybe a bundler can fix this?