### PR TITLE
Improve error handling on fragment gen fail

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -182,9 +182,11 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
     }
 });
 
-browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     if (message.doubleClickInterval) {
         doubleClickInterval = message.doubleClickInterval;
+    } else if (message.error) {
+        await showNotification('Error', message.error);
     }
 });
 

--- a/chromium/content.js
+++ b/chromium/content.js
@@ -197,19 +197,36 @@ function createTextFragmentArg(selection) {
     }
 
     // https://web.dev/articles/text-fragments#programmatic_text_fragment_link_generation
-    const result = window.generateFragment(selection);
+    let result;
+    try {
+        result = window.generateFragment(selection);
+    } catch (err) {
+        if (err.message !== 'window.generateFragment is not a function') {
+            browser.runtime.sendMessage({ error: err });
+            return '';
+        }
+    }
+
     switch (result.status) {
         case 1:
-            console.error('generateFragment: the selection provided could not be used');
+            browser.runtime.sendMessage({
+                error: 'text fragment: the selection provided could not be used'
+            });
             return '';
         case 2:
-            console.error('generateFragment: no unique fragment could be identified for this selection');
+            browser.runtime.sendMessage({
+                error: 'text fragment: no unique fragment could be identified for this selection'
+            });
             return '';
         case 3:
-            console.error('generateFragment: computation could not complete in time');
+            browser.runtime.sendMessage({
+                error: 'text fragment: computation could not complete in time'
+            });
             return '';
         case 4:
-            console.error('generateFragment: an exception was raised during generation');
+            browser.runtime.sendMessage({
+                error: 'text fragment: an exception was raised during generation'
+            });
             return '';
     }
 

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -176,9 +176,11 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
     }
 });
 
-browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     if (message.doubleClickInterval) {
         doubleClickInterval = message.doubleClickInterval;
+    } else if (message.error) {
+        await showNotification('Error', message.error);
     }
 });
 

--- a/firefox/create-text-fragment-arg.js
+++ b/firefox/create-text-fragment-arg.js
@@ -26,6 +26,10 @@
  * ```
  */
 
+if (typeof browser === 'undefined') {
+    var browser = chrome;
+}
+
 /**
  * enc URL-encodes a string, but also replaces '-' with '%2D' because the text fragment
  * generator appears to not handle '-' correctly.
@@ -51,19 +55,36 @@ function createTextFragmentArg(selection) {
     }
 
     // https://web.dev/articles/text-fragments#programmatic_text_fragment_link_generation
-    const result = window.generateFragment(selection);
+    let result;
+    try {
+        result = window.generateFragment(selection);
+    } catch (err) {
+        if (err.message !== 'window.generateFragment is not a function') {
+            browser.runtime.sendMessage({ error: err.message });
+            return '';
+        }
+    }
+
     switch (result.status) {
         case 1:
-            console.error('generateFragment: the selection provided could not be used');
+            browser.runtime.sendMessage({
+                error: 'text fragment: the selection provided could not be used'
+            });
             return '';
         case 2:
-            console.error('generateFragment: no unique fragment could be identified for this selection');
+            browser.runtime.sendMessage({
+                error: 'text fragment: no unique fragment could be identified for this selection'
+            });
             return '';
         case 3:
-            console.error('generateFragment: computation could not complete in time');
+            browser.runtime.sendMessage({
+                error: 'text fragment: computation could not complete in time'
+            });
             return '';
         case 4:
-            console.error('generateFragment: an exception was raised during generation');
+            browser.runtime.sendMessage({
+                error: 'text fragment: an exception was raised during generation'
+            });
             return '';
     }
 


### PR DESCRIPTION
Fixes #38.

When text fragment generation fails, markdown without a text fragment is written to the clipboard and a notification with an error message is shown. The green check still appears immediately; there doesn't appear to be a way to prevent this because the text fragment generator is synchronous.